### PR TITLE
add DeviceCodeCredential support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ token handling.
 - `cache`: Re-implements the azure-identity caching provider
 - `chained_token_credential`: Implements credential chaining to try multiple authentication methods.  This method has been added to an unreleased version of the upstream `azure_identity` crate.  This will be removed once the updated upstream crate is released.
 - `device_code`: Provides device code flow authentication support for Azure services.  Originally from `azure_identity` 0.20.0.
+- `devicecode_credentials`: Implements a credential that can authenticate using device code flow. Uses the `device_code` module's functionality.
 - `refresh_token`: Handles refresh token operations for maintaining authentication sessions.  Originally from `azure_identity` 0.20.0.
 
 

--- a/src/devicecode_credentials.rs
+++ b/src/devicecode_credentials.rs
@@ -1,0 +1,110 @@
+use crate::{cache::TokenCache, device_code::start, refresh_token::exchange};
+use async_lock::Mutex;
+use azure_core::{
+    credentials::{AccessToken, Secret, TokenCredential},
+    error::{Error, ErrorKind},
+};
+use azure_identity::TokenCredentialOptions;
+use futures::stream::StreamExt;
+use std::{collections::BTreeMap, str, sync::Arc, time::Duration};
+use time::OffsetDateTime;
+
+#[derive(Debug)]
+/// Enables authentication to an Azure Client using a Device Code workflow.
+pub struct DeviceCodeCredential {
+    tenant_id: String,
+    client_id: String,
+    cache: TokenCache,
+    refresh_tokens: Mutex<BTreeMap<Vec<String>, Secret>>,
+    options: TokenCredentialOptions,
+}
+
+impl DeviceCodeCredential {
+    /// Create a new `DeviceCodeCredential` with the specified tenant ID, client ID, and options.
+    pub fn new<T, C>(
+        tenant_id: T,
+        client_id: C,
+        options: TokenCredentialOptions,
+    ) -> azure_core::Result<Arc<Self>>
+    where
+        T: Into<String>,
+        C: Into<String>,
+    {
+        Ok(Arc::new(Self {
+            tenant_id: tenant_id.into(),
+            client_id: client_id.into(),
+            cache: TokenCache::new(),
+            refresh_tokens: Mutex::new(BTreeMap::new()),
+            options,
+        }))
+    }
+
+    async fn get_access_token(&self, scopes: &[&str]) -> azure_core::Result<AccessToken> {
+        let scopes_owned = scopes.iter().map(ToString::to_string).collect::<Vec<_>>();
+        let mut refresh_tokens = self.refresh_tokens.lock().await;
+        if let Some(refresh_token) = refresh_tokens.remove(&scopes_owned) {
+            let response = exchange(
+                self.options.http_client(),
+                self.tenant_id.as_str(),
+                &self.client_id,
+                None,
+                &refresh_token,
+            )
+            .await?;
+            let token = AccessToken {
+                token: response.access_token().to_owned(),
+                expires_on: OffsetDateTime::now_utc() + Duration::new(response.expires_in(), 0),
+            };
+            refresh_tokens.insert(scopes_owned, response.refresh_token().to_owned());
+            return Ok(token);
+        }
+
+        let flow = start(
+            self.options.http_client(),
+            self.tenant_id.to_string(),
+            self.client_id.as_str(),
+            scopes,
+        )
+        .await?;
+
+        eprintln!("{}", flow.message());
+
+        let mut stream = flow.stream();
+        let auth = loop {
+            let Some(response) = stream.next().await else {
+                return Err(Error::message(
+                    ErrorKind::Credential,
+                    "azureauth CLI did not return a response",
+                ));
+            };
+            if let Ok(auth) = response {
+                break auth;
+            }
+        };
+
+        let token = AccessToken {
+            token: auth.access_token().to_owned(),
+            expires_on: OffsetDateTime::now_utc() + Duration::new(auth.expires_in, 0),
+        };
+
+        if let Some(refresh_token) = auth.refresh_token() {
+            refresh_tokens.insert(scopes_owned, refresh_token.to_owned());
+        }
+        Ok(token)
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl TokenCredential for DeviceCodeCredential {
+    async fn get_token(&self, scopes: &[&str]) -> azure_core::Result<AccessToken> {
+        self.cache
+            .get_token(scopes, self.get_access_token(scopes))
+            .await
+    }
+
+    async fn clear_cache(&self) -> azure_core::Result<()> {
+        self.refresh_tokens.lock().await.clear();
+        self.cache.clear().await
+    }
+}

--- a/src/devicecode_credentials.rs
+++ b/src/devicecode_credentials.rs
@@ -53,7 +53,7 @@ impl DeviceCodeCredential {
             .await?;
             let token = AccessToken {
                 token: response.access_token().to_owned(),
-                expires_on: OffsetDateTime::now_utc() + Duration::new(response.expires_in(), 0),
+                expires_on: convert_expires_in(response.expires_in()),
             };
             refresh_tokens.insert(scopes_owned, response.refresh_token().to_owned());
             return Ok(token);
@@ -84,7 +84,7 @@ impl DeviceCodeCredential {
 
         let token = AccessToken {
             token: auth.access_token().to_owned(),
-            expires_on: OffsetDateTime::now_utc() + Duration::new(auth.expires_in, 0),
+            expires_on: convert_expires_in(auth.expires_in),
         };
 
         if let Some(refresh_token) = auth.refresh_token() {
@@ -107,4 +107,8 @@ impl TokenCredential for DeviceCodeCredential {
         self.refresh_tokens.lock().await.clear();
         self.cache.clear().await
     }
+}
+
+fn convert_expires_in(seconds: u64) -> OffsetDateTime {
+    OffsetDateTime::now_utc() + Duration::new(seconds, 0)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 //! - `cache`: Re-implements the azure-identity caching provider
 //! - `chained_token_credential`: Implements credential chaining to try multiple authentication methods.  This method has been added to an unreleased version of the upstream `azure_identity` crate.  This will be removed once the updated upstream crate is released.
 //! - `device_code`: Provides device code flow authentication support for Azure services.  Originally from `azure_identity` 0.20.0.
+//! - `devicecode_credentials`: Implements a credential that can authenticate using device code flow. Uses the `device_code` module's functionality.
 //! - `refresh_token`: Handles refresh token operations for maintaining authentication sessions.  Originally from `azure_identity` 0.20.0.
 //!
 
@@ -30,4 +31,5 @@ pub mod azureauth_cli_credentials;
 pub mod cache;
 pub mod chained_token_credential;
 pub mod device_code;
+pub mod devicecode_credentials;
 pub mod refresh_token;


### PR DESCRIPTION
`DeviceCodeCredential` enables using the device code workflow with `ChainedTokenCredential`.